### PR TITLE
use fastjson replace gson

### DIFF
--- a/jstorm-client-extension/pom.xml
+++ b/jstorm-client-extension/pom.xml
@@ -64,9 +64,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.googlecode.json-simple</groupId>
-			<artifactId>json-simple</artifactId>
-			<version>1.1</version>
+			<groupId>com.alibaba</groupId>
+			<artifactId>fastjson</artifactId>
+			<version>1.1.41</version>
 		</dependency>
 		<dependency>
 		  <groupId>com.sun.net.httpserver</groupId>

--- a/jstorm-client-extension/src/main/java/com/alibaba/jstorm/client/ConfigExtension.java
+++ b/jstorm-client-extension/src/main/java/com/alibaba/jstorm/client/ConfigExtension.java
@@ -6,10 +6,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.json.simple.JSONValue;
 
 import backtype.storm.Config;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.jstorm.utils.JStormUtils;
 
 public class ConfigExtension {
@@ -309,7 +309,7 @@ public class ConfigExtension {
 			List<WorkerAssignment> userDefines) {
 		List<String> ret = new ArrayList<String>();
 		for (WorkerAssignment worker : userDefines) {
-			ret.add(JSONValue.toJSONString(worker));
+			ret.add(JSON.toJSONString(worker));
 		}
 		conf.put(USE_USERDEFINE_ASSIGNMENT, ret);
 	}

--- a/jstorm-client-extension/src/main/java/com/alibaba/jstorm/client/WorkerAssignment.java
+++ b/jstorm-client-extension/src/main/java/com/alibaba/jstorm/client/WorkerAssignment.java
@@ -9,10 +9,11 @@ import java.util.Map.Entry;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.log4j.Logger;
-import org.json.simple.JSONAware;
-import org.json.simple.JSONValue;
 
 import backtype.storm.scheduler.WorkerSlot;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONAware;
 
 public class WorkerAssignment extends WorkerSlot implements Serializable,
 		JSONAware {
@@ -217,11 +218,11 @@ public class WorkerAssignment extends WorkerSlot implements Serializable,
 
 		// input.addComponent("2b", 2);
 
-		String outString = JSONValue.toJSONString(input);
+		String outString = JSON.toJSONString(input);
 
 		System.out.println(input);
 
-		Object object = JSONValue.parse(outString);
+		Object object = JSON.parse(outString);
 
 		System.out.println(parseFromObj(object));
 

--- a/jstorm-client-extension/src/main/java/com/alibaba/jstorm/utils/FileAttribute.java
+++ b/jstorm-client-extension/src/main/java/com/alibaba/jstorm/utils/FileAttribute.java
@@ -7,8 +7,9 @@ import java.util.Map;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
-import org.json.simple.JSONAware;
-import org.json.simple.JSONObject;
+
+import com.alibaba.fastjson.JSONAware;
+import com.alibaba.fastjson.JSONObject;
 
 public class FileAttribute implements Serializable, JSONAware {
 

--- a/jstorm-client-extension/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
+++ b/jstorm-client-extension/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
@@ -10,24 +10,18 @@ import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
-import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import javax.management.ReflectionException;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -35,10 +29,10 @@ import org.apache.commons.exec.ExecuteException;
 import org.apache.log4j.Appender;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
-import org.json.simple.JSONValue;
 
 import backtype.storm.utils.Utils;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.jstorm.callback.AsyncLoopDefaultKill;
 import com.alibaba.jstorm.callback.RunnableCallback;
 
@@ -303,14 +297,14 @@ public class JStormUtils {
 	// }
 
 	public static String to_json(Map m) {
-		return JSONValue.toJSONString(m);
+		return JSON.toJSONString(m);
 	}
 
 	public static Object from_json(String json) {
 		if (json == null) {
 			return null;
 		} else {
-			return JSONValue.parse(json);
+			return JSON.parse(json);
 		}
 	}
 

--- a/jstorm-client/pom.xml
+++ b/jstorm-client/pom.xml
@@ -120,9 +120,9 @@
 			<version>2.17</version>
 		</dependency>
 		<dependency>
-			<groupId>com.googlecode.json-simple</groupId>
-			<artifactId>json-simple</artifactId>
-			<version>1.1</version>
+			<groupId>com.alibaba</groupId>
+			<artifactId>fastjson</artifactId>
+			<version>1.1.41</version>
 		</dependency>
 		<dependency>
 			<groupId>storm</groupId>

--- a/jstorm-client/src/main/java/backtype/storm/StormSubmitter.java
+++ b/jstorm-client/src/main/java/backtype/storm/StormSubmitter.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.thrift7.TException;
-import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +20,8 @@ import backtype.storm.generated.TopologySummary;
 import backtype.storm.utils.BufferFileInputStream;
 import backtype.storm.utils.NimbusClient;
 import backtype.storm.utils.Utils;
+
+import com.alibaba.fastjson.JSON;
 
 /**
  * Use this class to submit topologies to run on the Storm cluster. You should
@@ -90,7 +91,7 @@ public class StormSubmitter {
 		conf.putAll(stormConf);
 		putUserInfo(conf, stormConf);
 		try {
-			String serConf = JSONValue.toJSONString(stormConf);
+			String serConf = JSON.toJSONString(stormConf);
 			if (localNimbus != null) {
 				LOG.info("Submitting topology " + name + " in local mode");
 				localNimbus.submitTopology(name, null, serConf, topology);

--- a/jstorm-client/src/main/java/backtype/storm/drpc/DRPCSpout.java
+++ b/jstorm-client/src/main/java/backtype/storm/drpc/DRPCSpout.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.thrift7.TException;
-import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +21,8 @@ import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
 import backtype.storm.utils.ServiceRegistry;
 import backtype.storm.utils.Utils;
+
+import com.alibaba.fastjson.JSON;
 
 public class DRPCSpout extends BaseRichSpout {
 	public static Logger LOG = LoggerFactory.getLogger(DRPCSpout.class);
@@ -99,7 +100,7 @@ public class DRPCSpout extends BaseRichSpout {
 						returnInfo.put("port", client.getPort());
 						gotRequest = true;
 						_collector.emit(new Values(req.get_func_args(),
-								JSONValue.toJSONString(returnInfo)),
+								JSON.toJSONString(returnInfo)),
 								new DRPCMessageId(req.get_request_id(), i));
 						break;
 					}
@@ -121,7 +122,7 @@ public class DRPCSpout extends BaseRichSpout {
 						returnInfo.put("port", 0);
 						gotRequest = true;
 						_collector.emit(new Values(req.get_func_args(),
-								JSONValue.toJSONString(returnInfo)),
+								JSON.toJSONString(returnInfo)),
 								new DRPCMessageId(req.get_request_id(), 0));
 					}
 				} catch (TException e) {

--- a/jstorm-client/src/main/java/backtype/storm/drpc/ReturnResults.java
+++ b/jstorm-client/src/main/java/backtype/storm/drpc/ReturnResults.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.thrift7.TException;
-import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +18,8 @@ import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.utils.ServiceRegistry;
 import backtype.storm.utils.Utils;
+
+import com.alibaba.fastjson.JSON;
 
 public class ReturnResults extends BaseRichBolt {
 	public static final Logger LOG = LoggerFactory
@@ -40,7 +41,7 @@ public class ReturnResults extends BaseRichBolt {
 		String result = (String) input.getValue(0);
 		String returnInfo = (String) input.getValue(1);
 		if (returnInfo != null) {
-			Map retMap = (Map) JSONValue.parse(returnInfo);
+			Map retMap = (Map) JSON.parse(returnInfo);
 			final String host = (String) retMap.get("host");
 			final int port = Utils.getInt(retMap.get("port"));
 			String id = (String) retMap.get("id");

--- a/jstorm-client/src/main/java/backtype/storm/spout/ShellSpout.java
+++ b/jstorm-client/src/main/java/backtype/storm/spout/ShellSpout.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.json.simple.JSONObject;
+import com.alibaba.fastjson.JSONObject;
 
 public class ShellSpout implements ISpout {
 	public static Logger LOG = LoggerFactory.getLogger(ShellSpout.class);

--- a/jstorm-client/src/main/java/backtype/storm/task/GeneralTopologyContext.java
+++ b/jstorm-client/src/main/java/backtype/storm/task/GeneralTopologyContext.java
@@ -1,5 +1,11 @@
 package backtype.storm.task;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import backtype.storm.Config;
 import backtype.storm.Constants;
 import backtype.storm.generated.ComponentCommon;
@@ -9,13 +15,9 @@ import backtype.storm.generated.StormTopology;
 import backtype.storm.tuple.Fields;
 import backtype.storm.utils.ThriftTopologyUtils;
 import backtype.storm.utils.Utils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.json.simple.JSONValue;
-import org.json.simple.JSONAware;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONAware;
 
 public class GeneralTopologyContext implements JSONAware {
 	private StormTopology _topology;
@@ -164,7 +166,7 @@ public class GeneralTopologyContext implements JSONAware {
 		obj.put("task->component", _taskToComponent);
 		// TODO: jsonify StormTopology
 		// at the minimum should send source info
-		return JSONValue.toJSONString(obj);
+		return JSON.toJSONString(obj);
 	}
 
 	/**
@@ -193,7 +195,7 @@ public class GeneralTopologyContext implements JSONAware {
 			ComponentCommon common = getComponentCommon(spout);
 			String jsonConf = common.get_json_conf();
 			if (jsonConf != null) {
-				Map conf = (Map) JSONValue.parse(jsonConf);
+				Map conf = (Map) JSON.parse(jsonConf);
 				Object comp = conf.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS);
 				if (comp != null) {
 					max = Math.max(Utils.getInt(comp), max);

--- a/jstorm-client/src/main/java/backtype/storm/task/ShellBolt.java
+++ b/jstorm-client/src/main/java/backtype/storm/task/ShellBolt.java
@@ -1,22 +1,25 @@
 package backtype.storm.task;
 
-import backtype.storm.generated.ShellComponent;
-import backtype.storm.tuple.MessageId;
-import backtype.storm.tuple.Tuple;
-import backtype.storm.utils.Utils;
-import backtype.storm.utils.ShellProcess;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.json.simple.JSONObject;
+
+import backtype.storm.generated.ShellComponent;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.utils.ShellProcess;
+import backtype.storm.utils.Utils;
+
+import com.alibaba.fastjson.JSONObject;
 
 /**
  * A bolt that shells out to another process to process tuples. ShellBolt

--- a/jstorm-client/src/main/java/backtype/storm/topology/TopologyBuilder.java
+++ b/jstorm-client/src/main/java/backtype/storm/topology/TopologyBuilder.java
@@ -1,5 +1,9 @@
 package backtype.storm.topology;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
 import backtype.storm.Config;
 import backtype.storm.generated.Bolt;
 import backtype.storm.generated.ComponentCommon;
@@ -14,11 +18,7 @@ import backtype.storm.grouping.CustomStreamGrouping;
 import backtype.storm.tuple.Fields;
 import backtype.storm.utils.Utils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.json.simple.JSONValue;
+import com.alibaba.fastjson.JSON;
 
 /**
  * TopologyBuilder exposes the Java API for specifying a topology for Storm to
@@ -263,7 +263,7 @@ public class TopologyBuilder {
 		}
 		Map conf = component.getComponentConfiguration();
 		if (conf != null)
-			common.set_json_conf(JSONValue.toJSONString(conf));
+			common.set_json_conf(JSON.toJSONString(conf));
 		_commons.put(id, common);
 	}
 
@@ -414,13 +414,13 @@ public class TopologyBuilder {
 		if (json == null)
 			return new HashMap();
 		else
-			return (Map) JSONValue.parse(json);
+			return (Map) JSON.parse(json);
 	}
 
 	private static String mergeIntoJson(Map into, Map newMap) {
 		Map res = new HashMap(into);
 		if (newMap != null)
 			res.putAll(newMap);
-		return JSONValue.toJSONString(res);
+		return JSON.toJSONString(res);
 	}
 }

--- a/jstorm-client/src/main/java/backtype/storm/utils/ShellProcess.java
+++ b/jstorm-client/src/main/java/backtype/storm/utils/ShellProcess.java
@@ -11,8 +11,8 @@ import java.util.Map;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.JSON;
 import org.apache.log4j.Logger;
 
 public class ShellProcess {
@@ -51,7 +51,7 @@ public class ShellProcess {
 	}
 
 	public void writeMessage(Object msg) throws IOException {
-		writeString(JSONValue.toJSONString(msg));
+		writeString(JSON.toJSONString(msg));
 	}
 
 	private void writeString(String str) throws IOException {
@@ -63,7 +63,7 @@ public class ShellProcess {
 
 	public JSONObject readMessage() throws IOException {
 		String string = readString();
-		JSONObject msg = (JSONObject) JSONValue.parse(string);
+		JSONObject msg = JSON.parseObject(string);
 		if (msg != null) {
 			return msg;
 		} else {

--- a/jstorm-client/src/main/java/backtype/storm/utils/Utils.java
+++ b/jstorm-client/src/main/java/backtype/storm/utils/Utils.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 import org.apache.commons.io.input.ClassLoaderObjectInputStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.thrift7.TException;
-import org.json.simple.JSONValue;
 import org.yaml.snakeyaml.Yaml;
 
 import backtype.storm.Config;
@@ -36,6 +35,7 @@ import backtype.storm.generated.StormTopology;
 import clojure.lang.IFn;
 import clojure.lang.RT;
 
+import com.alibaba.fastjson.JSON;
 import com.netflix.curator.framework.CuratorFramework;
 import com.netflix.curator.framework.CuratorFrameworkFactory;
 import com.netflix.curator.retry.ExponentialBackoffRetry;
@@ -255,7 +255,7 @@ public class Utils {
 
 	public static boolean isValidConf(Map<String, Object> stormConf) {
 		return normalizeConf(stormConf).equals(
-				normalizeConf((Map) JSONValue.parse(JSONValue
+				normalizeConf((Map) JSON.parse(JSON
 						.toJSONString(stormConf))));
 	}
 

--- a/jstorm-client/src/main/java/storm/trident/drpc/ReturnResultsReducer.java
+++ b/jstorm-client/src/main/java/storm/trident/drpc/ReturnResultsReducer.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.thrift7.TException;
-import org.json.simple.JSONValue;
 
 import storm.trident.drpc.ReturnResultsReducer.ReturnResultsState;
 import storm.trident.operation.MultiReducer;
@@ -19,6 +18,8 @@ import backtype.storm.drpc.DRPCInvocationsClient;
 import backtype.storm.generated.DistributedRPCInvocations;
 import backtype.storm.utils.ServiceRegistry;
 import backtype.storm.utils.Utils;
+
+import com.alibaba.fastjson.JSON;
 
 
 public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
@@ -59,8 +60,8 @@ public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
     public void complete(ReturnResultsState state, TridentCollector collector) {
         // only one of the multireducers will receive the tuples
         if(state.returnInfo!=null) {
-            String result = JSONValue.toJSONString(state.results);
-            Map retMap = (Map) JSONValue.parse(state.returnInfo);
+            String result = JSON.toJSONString(state.results);
+            Map retMap = (Map) JSON.parse(state.returnInfo);
             final String host = (String) retMap.get("host");
             final int port = Utils.getInt(retMap.get("port"));
             String id = (String) retMap.get("id");

--- a/jstorm-client/src/main/java/storm/trident/state/JSONNonTransactionalSerializer.java
+++ b/jstorm-client/src/main/java/storm/trident/state/JSONNonTransactionalSerializer.java
@@ -1,7 +1,8 @@
 package storm.trident.state;
 
 import java.io.UnsupportedEncodingException;
-import org.json.simple.JSONValue;
+
+import com.alibaba.fastjson.JSON;
 
 
 public class JSONNonTransactionalSerializer implements Serializer {
@@ -9,7 +10,7 @@ public class JSONNonTransactionalSerializer implements Serializer {
     @Override
     public byte[] serialize(Object obj) {
         try {
-            return JSONValue.toJSONString(obj).getBytes("UTF-8");
+            return JSON.toJSONString(obj).getBytes("UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -18,7 +19,7 @@ public class JSONNonTransactionalSerializer implements Serializer {
     @Override
     public Object deserialize(byte[] b) {
         try {
-            return JSONValue.parse(new String(b, "UTF-8"));
+            return JSON.parse(new String(b, "UTF-8"));
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/jstorm-client/src/main/java/storm/trident/state/JSONOpaqueSerializer.java
+++ b/jstorm-client/src/main/java/storm/trident/state/JSONOpaqueSerializer.java
@@ -3,7 +3,8 @@ package storm.trident.state;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
-import org.json.simple.JSONValue;
+
+import com.alibaba.fastjson.JSON;
 
 
 public class JSONOpaqueSerializer implements Serializer<OpaqueValue> {
@@ -15,7 +16,7 @@ public class JSONOpaqueSerializer implements Serializer<OpaqueValue> {
         toSer.add(obj.curr);
         toSer.add(obj.prev);
         try {
-            return JSONValue.toJSONString(toSer).getBytes("UTF-8");
+            return JSON.toJSONString(toSer).getBytes("UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -25,7 +26,7 @@ public class JSONOpaqueSerializer implements Serializer<OpaqueValue> {
     public OpaqueValue deserialize(byte[] b) {
         try {
             String s = new String(b, "UTF-8");
-            List deser = (List) JSONValue.parse(s);
+            List deser = (List) JSON.parse(s);
             return new OpaqueValue((Long) deser.get(0), deser.get(1), deser.get(2));
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/jstorm-client/src/main/java/storm/trident/state/JSONTransactionalSerializer.java
+++ b/jstorm-client/src/main/java/storm/trident/state/JSONTransactionalSerializer.java
@@ -3,7 +3,8 @@ package storm.trident.state;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
-import org.json.simple.JSONValue;
+
+import com.alibaba.fastjson.JSON;
 
 
 public class JSONTransactionalSerializer implements Serializer<TransactionalValue> {
@@ -13,7 +14,7 @@ public class JSONTransactionalSerializer implements Serializer<TransactionalValu
         toSer.add(obj.getTxid());
         toSer.add(obj.getVal());
         try {
-            return JSONValue.toJSONString(toSer).getBytes("UTF-8");
+            return JSON.toJSONString(toSer).getBytes("UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -23,7 +24,7 @@ public class JSONTransactionalSerializer implements Serializer<TransactionalValu
     public TransactionalValue deserialize(byte[] b) {
         try {
             String s = new String(b, "UTF-8");
-            List deser = (List) JSONValue.parse(s);
+            List deser = (List) JSON.parse(s);
             return new TransactionalValue((Long) deser.get(0), deser.get(1));
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/jstorm-client/src/main/java/storm/trident/testing/TuplifyArgs.java
+++ b/jstorm-client/src/main/java/storm/trident/testing/TuplifyArgs.java
@@ -1,17 +1,19 @@
 package storm.trident.testing;
 
 import java.util.List;
-import org.json.simple.JSONValue;
+
 import storm.trident.operation.BaseFunction;
 import storm.trident.operation.TridentCollector;
 import storm.trident.tuple.TridentTuple;
+
+import com.alibaba.fastjson.JSON;
 
 public class TuplifyArgs extends BaseFunction {
 
     @Override
     public void execute(TridentTuple input, TridentCollector collector) {
         String args = input.getString(0);
-        List<List<Object>> tuples = (List) JSONValue.parse(args);
+        List<List<Object>> tuples = (List) JSON.parse(args);
         for(List<Object> tuple: tuples) {
             collector.emit(tuple);
         }

--- a/jstorm-client/src/main/java/storm/trident/topology/state/TransactionalState.java
+++ b/jstorm-client/src/main/java/storm/trident/topology/state/TransactionalState.java
@@ -1,17 +1,20 @@
 package storm.trident.topology.state;
 
 
-import backtype.storm.Config;
-import backtype.storm.utils.Utils;
-import com.netflix.curator.framework.CuratorFramework;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.json.simple.JSONValue;
+
+import backtype.storm.Config;
+import backtype.storm.utils.Utils;
+
+import com.alibaba.fastjson.JSON;
+import com.netflix.curator.framework.CuratorFramework;
 
 public class TransactionalState {
     CuratorFramework _curator;
@@ -49,7 +52,7 @@ public class TransactionalState {
         path = "/" + path;
         byte[] ser;
         try {
-            ser = JSONValue.toJSONString(obj).getBytes("UTF-8");
+            ser = JSON.toJSONString(obj).getBytes("UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -97,7 +100,7 @@ public class TransactionalState {
         path = "/" + path;
         try {
             if(_curator.checkExists().forPath(path)!=null) {
-                return JSONValue.parse(new String(_curator.getData().forPath(path), "UTF-8"));
+                return JSON.parse(new String(_curator.getData().forPath(path), "UTF-8"));
             } else {
                 return null;
             }

--- a/jstorm-server/src/main/java/com/alibaba/jstorm/local/LocalCluster.java
+++ b/jstorm-server/src/main/java/com/alibaba/jstorm/local/LocalCluster.java
@@ -6,7 +6,6 @@ import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.thrift7.TException;
-import org.json.simple.JSONValue;
 
 import backtype.storm.ILocalCluster;
 import backtype.storm.generated.AlreadyAliveException;
@@ -20,6 +19,8 @@ import backtype.storm.generated.SubmitOptions;
 import backtype.storm.generated.TopologyAssignException;
 import backtype.storm.generated.TopologyInfo;
 import backtype.storm.utils.Utils;
+
+import com.alibaba.fastjson.JSON;
 
 public class LocalCluster implements ILocalCluster {
 
@@ -44,7 +45,7 @@ public class LocalCluster implements ILocalCluster {
 			throw new RuntimeException("Topology conf is not json-serializable");
 		try {
 			state.getNimbus().submitTopology(topologyName, null,
-					JSONValue.toJSONString(conf), topology);
+					JSON.toJSONString(conf), topology);
 		} catch (TopologyAssignException e) {
 			// TODO Auto-generated catch block
 			LOG.error("Failed to submit topology " + topologyName, e);
@@ -63,7 +64,7 @@ public class LocalCluster implements ILocalCluster {
 			throw new RuntimeException("Topology conf is not json-serializable");
 		try {
 			state.getNimbus().submitTopologyWithOpts(topologyName, null,
-					JSONValue.toJSONString(conf), topology, submitOpts);
+					JSON.toJSONString(conf), topology, submitOpts);
 		} catch (TopologyAssignException e) {
 			// TODO Auto-generated catch block
 			LOG.error("Failed to submit topology " + topologyName, e);

--- a/jstorm-server/src/main/java/com/alibaba/jstorm/utils/JStromServerConfigExtension.java
+++ b/jstorm-server/src/main/java/com/alibaba/jstorm/utils/JStromServerConfigExtension.java
@@ -4,11 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.json.simple.JSONValue;
-
+import com.alibaba.fastjson.JSON;
 import com.alibaba.jstorm.client.ConfigExtension;
 import com.alibaba.jstorm.client.WorkerAssignment;
-import com.alibaba.jstorm.utils.JStormUtils;
 
 public class JStromServerConfigExtension extends ConfigExtension {
 
@@ -17,7 +15,7 @@ public class JStromServerConfigExtension extends ConfigExtension {
 		if (conf.get(USE_USERDEFINE_ASSIGNMENT) == null)
 			return ret;
 		for (String worker : (List<String>) conf.get(USE_USERDEFINE_ASSIGNMENT)) {
-			ret.add(WorkerAssignment.parseFromObj(JSONValue.parse(worker)));
+			ret.add(WorkerAssignment.parseFromObj(JSON.parse(worker)));
 		}
 		return ret;
 	}

--- a/jstorm-ui/src/main/java/com/alibaba/jstorm/ui/model/data/ListLogPage.java
+++ b/jstorm-ui/src/main/java/com/alibaba/jstorm/ui/model/data/ListLogPage.java
@@ -16,8 +16,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.apache.log4j.Logger;
-import org.json.simple.JSONObject;
 
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.jstorm.client.ConfigExtension;
 import com.alibaba.jstorm.ui.UIUtils;
 import com.alibaba.jstorm.utils.FileAttribute;


### PR DESCRIPTION
使用阿里巴巴自身的开源json库fastjson，替代gson。
替换理由：
1、公司内自由产品，能够得到直接支持。
2、成熟稳定，使用广泛
