### PR TITLE
cleanup:remove MaxTenuringThreshold in jstorm ui default config

### DIFF
--- a/jstorm-ui/src/main/resources/defaults.yaml
+++ b/jstorm-ui/src/main/resources/defaults.yaml
@@ -95,7 +95,7 @@ supervisor.disk.slot: null
 # worker gc configuration
 # worker.gc.path will put all gc logs and memory dump file
 worker.gc.path: "%JSTORM_HOME%/logs"
-worker.gc.childopts: " -XX:SurvivorRatio=4 -XX:MaxTenuringThreshold=20 -XX:+UseConcMarkSweepGC  -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=80 -XX:CMSFullGCsBeforeCompaction=5 -XX:+HeapDumpOnOutOfMemoryError -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseCMSCompactAtFullCollection -XX:CMSMaxAbortablePrecleanTime=5000 "
+worker.gc.childopts: " -XX:SurvivorRatio=4 -XX:+UseConcMarkSweepGC  -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=80 -XX:CMSFullGCsBeforeCompaction=5 -XX:+HeapDumpOnOutOfMemoryError -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseCMSCompactAtFullCollection -XX:CMSMaxAbortablePrecleanTime=5000 "
 worker.heartbeat.frequency.secs: 2
 worker.classpath: ""
 worker.redirect.output: true


### PR DESCRIPTION
for OpenJDK 8,MaxTenuringThreshold`s max allowed value is 15,not 20.
to avoid such problem,remove MaxTenuringThreshold option completely.