### PR TITLE
add oschina maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,18 @@
 	</dependencies>
 
 	<repositories>
+        <repository>
+            <id>nexus</id>
+            <name>local private nexus</name>
+            <url>http://maven.oschina.net/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
 		<repository>
 			<id>taobao</id>
 			<url>http://mvnrepo.code.taobao.org/nexus/content/repositories/releases/</url>


### PR DESCRIPTION
I building jstorm from source code but I found some jar local at taobao's repo .
Add oschina's maven repo maybe faster . 
But jstorm had submitted to Apache Foundation will merge into Apache-Storm , pom repo will modify .
