### PR TITLE
支持同一个Tepology中多个KafkaSpout

### DIFF
--- a/jstorm-utility/jstorm-kafka/src/main/java/com/alibaba/jstorm/kafka/KafkaSpout.java
+++ b/jstorm-utility/jstorm-kafka/src/main/java/com/alibaba/jstorm/kafka/KafkaSpout.java
@@ -31,7 +31,7 @@ public class KafkaSpout implements IRichSpout {
 	private ZkState zkState;
 	
 	public KafkaSpout() {
-	    config = new KafkaSpoutConfig();
+	    
 	}
 	
 	public KafkaSpout(KafkaSpoutConfig config) {
@@ -40,9 +40,11 @@ public class KafkaSpout implements IRichSpout {
 	
 	@Override
 	public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
-		// TODO Auto-generated method stub
 		this.collector = collector;
-		config.configure(conf);
+		if (this.config == null) {
+			config = new KafkaSpoutConfig();
+			config.configure(conf);
+		}
 		zkState = new ZkState(conf, config);
 		coordinator = new PartitionCoordinator(conf, config, context, zkState);
 		lastUpdateMs = System.currentTimeMillis();


### PR DESCRIPTION
为了支持多个KafkaSpout，配置文件中会有多个kafka的配置，所以open函数中不能自动调用config.configure(conf); 方法。
同时为了继续支持原来无参构造函数，增加判断，如果this.config == null再自动调用config.configure(conf);