### PR TITLE
fix supervisor heartbeat bug about slots number in 2.1.1

### DIFF
--- a/jstorm-core/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
@@ -1423,7 +1423,7 @@ public class JStormUtils {
         List<Integer> portList = (List<Integer>) conf.get(Config.SUPERVISOR_SLOTS_PORTS);
 
         if (portList != null && portList.size() > 0) {
-            return portList;
+            return new ArrayList<Integer>(portList);
         }
 
         int sysCpuNum = 4;


### PR DESCRIPTION
if user set slots, return a copy of this slots 