### PR TITLE
fix can't consume zero offset bug

### DIFF
--- a/jstorm-utility/jstorm-kafka/src/main/java/com/alibaba/jstorm/kafka/PartitionConsumer.java
+++ b/jstorm-utility/jstorm-kafka/src/main/java/com/alibaba/jstorm/kafka/PartitionConsumer.java
@@ -124,8 +124,12 @@ public class PartitionConsumer {
         ByteBufferMessageSet msgs;
         try {
             long start = System.currentTimeMillis();
-            msgs = consumer.fetchMessages(partition, emittingOffset + 1);
-            
+            if(config.fromBeginning){
+                msgs = consumer.fetchMessages(partition, emittingOffset);
+            }else {
+                msgs = consumer.fetchMessages(partition, emittingOffset + 1);
+            }
+
             if (msgs == null) {
             	short fetchResponseCode = consumer.getAndResetFetchResponseCode();
             	if (fetchResponseCode == ErrorMapping.OffsetOutOfRangeCode()) {


### PR DESCRIPTION
修复kafkaSpout 无法消费每个partition 0 offset 消息的bug