### PR TITLE
jstorm  获取系统(linux)获取可用内存应该使用/proc/meminfo中的MemAvailable

### DIFF
--- a/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/supervisor/Heartbeat.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/supervisor/Heartbeat.java
@@ -202,7 +202,7 @@ class Heartbeat extends RunnableCallback {
         if (cpuUsage <= 0.0 || !ConfigExtension.isSupervisorEnableAutoAdjustSlots(conf)) {
             return defaultPortList;
         }
-        long freeMemory = JStormUtils.getFreePhysicalMem() * 1024L;
+        long freeMemory = JStormUtils.getAvailablePhysicalMem() * 1024L;
 
         long reserveMemory = ConfigExtension.getStormMachineReserveMem(conf);
 

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
@@ -518,6 +518,10 @@ public class JStormUtils {
         return LinuxResource.getFreePhysicalMem();
     }
 
+    public static Long getAvailablePhysicalMem() {
+        return LinuxResource.getAvailablePhysicalMem();
+    }
+
     public static int getNumProcessors() {
         return LinuxResource.getProcessNum();
     }

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/utils/LinuxResource.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/utils/LinuxResource.java
@@ -185,7 +185,19 @@ public class LinuxResource {
         }
         return 0L;
     }
-
+    public static Long getAvailablePhysicalMem() {
+        if (!OSInfo.isLinux()) {
+            return 0L;
+        }
+        try {
+            List<String> lines = IOUtils.readLines(new FileInputStream(PROCFS_MEMINFO));
+            String free = lines.get(2).split("\\s+")[1];
+            return Long.valueOf(free);
+        } catch (Exception ignored) {
+            LOG.warn("failed to get total free memory.");
+        }
+        return 0L;
+    }
     /**
      * calcute the disk usage at current filesystem
      * @return


### PR DESCRIPTION
3.14 版本后   在/proc/meminfo文件中新增了一个选项


MemTotal:        7662552 kB
MemFree:          602996 kB
MemAvailable:    6005852 kB      


应该只用MemAvailable去计算系统的free内存比较合理。

MemAvailable的意义如下：
Many load balancing and workload placing programs check /proc/meminfo to estimate how much free memory is available. They generally do this by adding up "free" and "cached", which was fine ten years ago, but is pretty much guaranteed to be wrong today.
It is wrong because Cached includes memory that is not freeable as page cache, for example shared memory segments, tmpfs, and ramfs, and it does not include reclaimable slab memory, which can take up a large fraction of system memory on mostly idle systems with lots of files.Currently, the amount of memory that is available for a new workload,without pushing the system into swap, can be estimated from MemFree, Active(file), Inactive(file), and SReclaimable, as well as the "low"watermarks from /proc/zoneinfo.However, this may change in the future, and user space really should not be expected to know kernel internals to come up with an estimate for the amount of free memory.It is more convenient to provide such an estimate in /proc/meminfo. If things change in the future, we only have to change it in one place


