### PR TITLE
update parent pom's java-doc configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.1</version>
+          <configuration>
+            <additionalparam>-Xdoclint:none</additionalparam>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -339,9 +339,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.1</version>
-          <configuration>
-            <additionalparam>-Xdoclint:none</additionalparam>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -407,11 +404,11 @@
         </executions>
       </plugin>
       
-      <!--
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
               <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
               <reportOutputDirectory>./docs/javadoc</reportOutputDirectory>
           </configuration>
@@ -431,7 +428,7 @@
               </execution>
           </executions>
       </plugin>
-                           -->
+
       <!--
       // if release jstorm to maven center repository
       // please set parent as oss-parent


### PR DESCRIPTION
avoid install(javadoc plugin) failure in java8.
see this issue: https://github.com/alibaba/jstorm/issues/363