### PR TITLE
make DistributedRPC.py more Pythonic

### DIFF
--- a/jstorm-core/src/main/py/storm/DistributedRPC.py
+++ b/jstorm-core/src/main/py/storm/DistributedRPC.py
@@ -13,7 +13,7 @@ from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 try:
   from thrift.protocol import fastbinary
-except:
+except ImportError:
   fastbinary = None
 
 


### PR DESCRIPTION
base on the PEP8：

> When catching exceptions, mention specific exceptions whenever possible instead of using a bare except: clause.