### PR TITLE
Modify JStormUtils.java

### DIFF
--- a/jstorm-core/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java
@@ -112,14 +112,10 @@ public class JStormUtils {
     private static ThreadLocal<TDeserializer> threadDes = new ThreadLocal<TDeserializer>();
 
     public static String getErrorInfo(String baseInfo, Exception e) {
-        try {
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
-            return baseInfo + "\r\n" + sw.toString() + "\r\n";
-        } catch (Exception e2) {
-            return baseInfo;
-        }
+        if (baseInfo == null) {
+            return getErrorInfo(e);
+        } else
+            return baseInfo + "\r\n" + getErrorInfo(e) + "\r\n";
     }
 
     public static String getErrorInfo(Throwable error) {


### PR DESCRIPTION
modify jstorm-core/src/main/java/com/alibaba/jstorm/utils/JStormUtils.java.I'm not sure which is better,and base one the **DRY**(Don't Repeat Yourself Principle),This can be considered.(although this method seems never used?always use `public static String getErrorInfo(Throwable error)`