### PR TITLE
Change jstorm python env

### DIFF
--- a/bin/jstorm.py
+++ b/bin/jstorm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
如果默认是环境是python3，执行jstorm会报错，强制使用python2