### PR TITLE
fileencoding from latin1 to UTF-8

### DIFF
--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/LoadConfig.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/LoadConfig.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 
 public class LoadConfig {
 	public static final String TOPOLOGY_TYPE = "topology.type";
-	
+
 	private static Map LoadProperty(String prop) {
 		Map ret = null;
 		Properties properties = new Properties();

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/TestTopology.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/TestTopology.java
@@ -74,7 +74,6 @@ public class TestTopology {
 		}
 
 		return false;
-
 	}
 
 }

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/OnsConfig.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/OnsConfig.java
@@ -12,7 +12,7 @@ import com.aliyun.openservices.ons.api.PropertyKeyConst;
 public class OnsConfig implements Serializable{
 
 	private static final long serialVersionUID = -3911741873533333336L;
-	
+
 	private final String topic;
 	private final String subExpress;
 	private final String accessKey;

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/OnsTuple.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/OnsTuple.java
@@ -13,7 +13,7 @@ public class OnsTuple implements Serializable {
 
 	/**  */
 	private static final long serialVersionUID = 2277714452693486955L;
-
+	
 	protected final Message message;
 
 	protected final AtomicInteger failureTimes;

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/consumer/ConsumerConfig.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/consumer/ConsumerConfig.java
@@ -14,7 +14,7 @@ public class ConsumerConfig extends OnsConfig{
 	private final String consumerId;
 	private final int    consumerThreadNum;
 	
-	
+
 	private final String nameServer;
 	
 	

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/consumer/ConsumerFactory.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/consumer/ConsumerFactory.java
@@ -17,7 +17,7 @@ public class ConsumerFactory {
 	public static Map<String, Consumer> consumers = new HashMap<String, Consumer>();
 
 	public static synchronized Consumer mkInstance(ConsumerConfig consumerConfig, MessageListener listener) throws Exception {
-		
+	    
 
 		String consumerId = consumerConfig.getConsumerId();
 		Consumer consumer = consumers.get(consumerId);

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/consumer/ConsumerSpout.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/consumer/ConsumerSpout.java
@@ -30,7 +30,7 @@ public class ConsumerSpout implements IRichSpout, IAckValueSpout, IFailValueSpou
     public static final String ONS_SPOUT_FLOW_CONTROL = "OnsSpoutFlowControl";
     public static final String ONS_SPOUT_AUTO_ACK = "OnsSpoutAutoAck";
     public static final String ONS_MSG_MAX_FAIL_TIMES = "OnsMsgMaxFailTimes";
-
+    
     protected SpoutOutputCollector collector;
     protected transient Consumer consumer;
     protected transient ConsumerConfig consumerConfig;

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerBolt.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerBolt.java
@@ -21,7 +21,6 @@ public class ProducerBolt implements IRichBolt {
     private static final long serialVersionUID = 2495121976857546346L;
     
     private static final Logger LOG              = Logger.getLogger(ProducerBolt.class);
-
     protected OutputCollector      collector;
     protected ProducerConfig       producerConfig;
     protected Producer             producer;
@@ -51,16 +50,16 @@ public class ProducerBolt implements IRichBolt {
         			producerConfig.getTopic(),
         			producerConfig.getSubExpress(),
         			//Message Body
-        			//ÈÎºÎ¶ş½øÖÆĞÎÊ½µÄÊı¾İ£¬ONS²»×öÈÎºÎ¸ÉÔ¤£¬ĞèÒªProducerÓëConsumerĞ­ÉÌºÃÒ»ÖÂµÄĞòÁĞ»¯ºÍ·´ĞòÁĞ»¯·½Ê½
+                    //ä»»ä½•äºŒè¿›åˆ¶å½¢å¼çš„æ•°æ®ï¼ŒONSä¸åšä»»ä½•å¹²é¢„ï¼Œéœ€è¦Producerä¸Consumeråå•†å¥½ä¸€è‡´çš„åºåˆ—åŒ–å’Œååºåˆ—åŒ–æ–¹å¼
         			msgTuple.getMessage().getBody());
         	
-        	// ÉèÖÃ´ú±íÏûÏ¢µÄÒµÎñ¹Ø¼üÊôĞÔ£¬Çë¾¡¿ÉÄÜÈ«¾ÖÎ¨Ò»¡£
-        	// ÒÔ·½±ãÄúÔÚÎŞ·¨Õı³£ÊÕµ½ÏûÏ¢Çé¿öÏÂ£¬¿ÉÍ¨¹ıONS Console²éÑ¯ÏûÏ¢²¢²¹·¢¡£
-        	// ×¢Òâ£º²»ÉèÖÃÒ²²»»áÓ°ÏìÏûÏ¢Õı³£ÊÕ·¢
+        	// è®¾ç½®ä»£è¡¨æ¶ˆæ¯çš„ä¸šåŠ¡å…³é”®å±æ€§ï¼Œè¯·å°½å¯èƒ½å…¨å±€å”¯ä¸€ã€‚
+            // ä»¥æ–¹ä¾¿æ‚¨åœ¨æ— æ³•æ­£å¸¸æ”¶åˆ°æ¶ˆæ¯æƒ…å†µä¸‹ï¼Œå¯é€šè¿‡ONS ConsoleæŸ¥è¯¢æ¶ˆæ¯å¹¶è¡¥å‘ã€‚
+            // æ³¨æ„ï¼šä¸è®¾ç½®ä¹Ÿä¸ä¼šå½±å“æ¶ˆæ¯æ­£å¸¸æ”¶å‘
         	if (msgTuple.getMessage().getKey() != null) {
         		msg.setKey(msgTuple.getMessage().getKey());
         	}
-        	//·¢ËÍÏûÏ¢£¬Ö»Òª²»Å×Òì³£¾ÍÊÇ³É¹¦
+            //å‘é€æ¶ˆæ¯ï¼Œåªè¦ä¸æŠ›å¼‚å¸¸å°±æ˜¯æˆåŠŸ
         	sendResult = producer.send(msg);
         	
             LOG.info("Success send msg of " + msgTuple.getMessage().getMsgID());

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerConfig.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerConfig.java
@@ -18,7 +18,7 @@ public class ProducerConfig extends OnsConfig{
 		if (producerId == null) {
 			throw new RuntimeException(PropertyKeyConst.ProducerId + " hasn't been set");
 		}
-		
+
 		
 	}
 

--- a/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerFactory.java
+++ b/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerFactory.java
@@ -35,7 +35,6 @@ public class ProducerFactory {
 		producer = ONSFactory.createProducer(properties);
 		producer.start();
 
-
 		producers.put(producerId, producer);
 		LOG.info("Successfully create " + producerId + " producer");
 


### PR DESCRIPTION
jstorm-utility/ons 这个工程下面java文件文件编码为latin1,其它工程都为UTF-8,直接git clone下来之后,按照文档,
mvn clean
mvn package assembly:assembly -Dmaven.test.skip=true

编译不通过,报错
"
[ERROR] /home/glowd/repo/jstorm/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerBolt.java:58: 错误: 编码UTF-8的不可映射字符
[ERROR] // �Է��������޷������յ���Ϣ����£���ͨ��ONS Console��ѯ��Ϣ��������
[ERROR] ^
[ERROR] /home/glowd/repo/jstorm/jstorm-utility/ons/src/main/java/com/alibaba/jstorm/ons/producer/ProducerBolt.java:58: 错误: 编码UTF-8的不可映射字符
"
现在全部java文件编码改为UTF-8后,编译通过