### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs/jstorm-doc/Maintenance/DynamicAdjustLog.md
+++ b/docs/jstorm-doc/Maintenance/DynamicAdjustLog.md
@@ -2,7 +2,7 @@
 title:  "Dynamic Adjust Log"
 # Top-level navigation
 top-nav-group: Maintenance
-#top-nav-pos: 1
+# top-nav-pos: 1
 top-nav-title: Dynamic Adjust Log
 ---
 

--- a/docs/jstorm-doc/Maintenance_cn/DynamicAdjustLog.md
+++ b/docs/jstorm-doc/Maintenance_cn/DynamicAdjustLog.md
@@ -4,7 +4,7 @@ layout: plain_cn
 
 # Top-level navigation
 top-nav-group: Maintenance_cn
-#top-nav-pos: 1
+# top-nav-pos: 1
 top-nav-id: DynamicAdjustLog_cn
 top-nav-title: 动态调整日志
 ---

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/API.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/API.md
@@ -1,7 +1,7 @@
 ---
 title:  "API Introduction"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: API
 sub-nav-pos: 2

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/API/Grouping.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/API/Grouping.md
@@ -6,7 +6,7 @@ title: "Grouping method introduce"
 sub-nav-parent: API
 sub-nav-group: AdvancedUsage
 sub-nav-id: Grouping
-#sub-nav-pos: 3
+# sub-nav-pos: 3
 sub-nav-title: Grouping Introduce
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/API/IBasicBolt.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/API/IBasicBolt.md
@@ -6,7 +6,7 @@ title: "IBasicBolt interface introduce"
 sub-nav-parent: API
 sub-nav-group: AdvancedUsage
 sub-nav-id: IBasicBolt
-#sub-nav-pos: 3
+# sub-nav-pos: 3
 sub-nav-title: IBasicBolt Introduce
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/BackPressure.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/BackPressure.md
@@ -1,7 +1,7 @@
 ---
 title:  "BackPressure on JStorm"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: BackPressure
 sub-nav-pos: 9

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/BlobStore.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/BlobStore.md
@@ -2,10 +2,10 @@
 title:  "How to use BlobStore"
 
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: BlobStore
-#sub-nav-pos: 6
+# sub-nav-pos: 6
 sub-nav-title: BlobStore
 
 ---

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust.md
@@ -1,7 +1,7 @@
 ---
 title:  "Dynamic Adjust Application"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: DynamicAdjust
 sub-nav-pos: 6

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust/Configuration.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust/Configuration.md
@@ -6,7 +6,7 @@ title: "Dynamic Adjust application configuration"
 sub-nav-parent: DynamicAdjust
 sub-nav-group: AdvancedUsage
 sub-nav-id: Configuration
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: Dynamic-Adjust-Configuration
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust/Metrics.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust/Metrics.md
@@ -6,7 +6,7 @@ title: "Dynamic Adjust metrics, enable/disable metrics"
 sub-nav-parent: DynamicAdjust
 sub-nav-group: AdvancedUsage
 sub-nav-id: Metrics
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: Dynamic-Adjust-Metrics
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust/Parallel.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/DynamicAdjust/Parallel.md
@@ -6,7 +6,7 @@ title: "Dynamic Adjust application worker/task's Parallel"
 sub-nav-parent: DynamicAdjust
 sub-nav-group: AdvancedUsage
 sub-nav-id: Parallel
-#sub-nav-pos: 3
+# sub-nav-pos: 3
 sub-nav-title: Dynamic-Adjust-Parallel
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/PerformanceTuning.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/PerformanceTuning.md
@@ -1,7 +1,7 @@
 ---
 title:  "How to tune performance?"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: PerformanceTuning
 sub-nav-pos: 10

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Plugins.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Plugins.md
@@ -1,7 +1,7 @@
 ---
 title:  "Plugins"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: Plugins
 sub-nav-pos: 4

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Plugins/Flux.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Plugins/Flux.md
@@ -6,7 +6,7 @@ title: "Flux Plugin, Generate Topology by configuration"
 sub-nav-parent: Plugins
 sub-nav-group: AdvancedUsage
 sub-nav-id: Flux
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: Flux Plugin
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Plugins/Hdfs.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Plugins/Hdfs.md
@@ -6,7 +6,7 @@ title: "HDFS Plugin"
 sub-nav-parent: Plugins
 sub-nav-group: AdvancedUsage
 sub-nav-id: HDFS
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: HDFS Plugin
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/SQL.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/SQL.md
@@ -1,7 +1,7 @@
 ---
 title:  "How to run SQL on jstorm"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: SQL
 sub-nav-pos: 7

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/SubmitTopology.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/SubmitTopology.md
@@ -1,7 +1,7 @@
 ---
 title:  "How to use Submit Topology by external system?"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: SubmitTopology
 sub-nav-pos: 8

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Theory.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Theory.md
@@ -1,7 +1,7 @@
 ---
 title:  "Run mechanism & Theory"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: Theory
 sub-nav-pos: 3

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Theory/Acker.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Theory/Acker.md
@@ -6,7 +6,7 @@ title: "Acker"
 sub-nav-parent: Theory
 sub-nav-group: AdvancedUsage
 sub-nav-id: Acker
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: Acker mechanism
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined.md
@@ -1,7 +1,7 @@
 ---
 title:  "User Defined Features"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: UserDefined
 sub-nav-pos: 5

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Alarm.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Alarm.md
@@ -6,7 +6,7 @@ title: "User Defined Alarm, report error to system"
 sub-nav-parent: UserDefined
 sub-nav-group: AdvancedUsage
 sub-nav-id: Alarm
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: User-Defined-Alarm
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Log.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Log.md
@@ -6,7 +6,7 @@ title: "User Defined Log, Switch log4j/logback, Use user's log configuration"
 sub-nav-parent: UserDefined
 sub-nav-group: AdvancedUsage
 sub-nav-id: Log
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: User-Defined-Log
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Metrics.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Metrics.md
@@ -6,7 +6,7 @@ title: "User Defined Metrics, Monitor application's key Metrics"
 sub-nav-parent: UserDefined
 sub-nav-group: AdvancedUsage
 sub-nav-id: Metrics
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: User-Defined-Metrics
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Scheduler.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/UserDefined/Scheduler.md
@@ -6,7 +6,7 @@ title: "User Defined Scheduler, Assign worker whatever user want"
 sub-nav-parent: UserDefined
 sub-nav-group: AdvancedUsage
 sub-nav-id: Scheduler
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: User-Defined-Scheduler
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Window.md
+++ b/docs/jstorm-doc/ProgrammingGuide/AdvancedUsage/Window.md
@@ -1,7 +1,7 @@
 ---
 title:  "How to use Window Framework?"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage
 sub-nav-id: Window
 sub-nav-pos: 9

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/API.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/API.md
@@ -1,7 +1,7 @@
 ---
 title:  "API 介绍"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: API_cn
 sub-nav-pos: 2

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/API/Grouping.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/API/Grouping.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: API_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Grouping_cn
-#sub-nav-pos: 3
+# sub-nav-pos: 3
 sub-nav-title: Grouping 介绍
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/API/IBasicBolt.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/API/IBasicBolt.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: API_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: IBasicBolt_cn
-#sub-nav-pos: 3
+# sub-nav-pos: 3
 sub-nav-title: IBasicBolt 介绍
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/BackPressure.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/BackPressure.md
@@ -1,7 +1,7 @@
 ---
 title:  "JStorm 限流控制/反压"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: BackPressure_cn
 sub-nav-pos: 9

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/BlobStore.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/BlobStore.md
@@ -6,7 +6,7 @@ layout: plain_cn
 # Top-level navigation
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: BlobStore_cn
-#sub-nav-pos: 7
+# sub-nav-pos: 7
 sub-nav-title: BlobStore
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust.md
@@ -1,7 +1,7 @@
 ---
 title:  "Dynamic Adjust Application"
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: DynamicAdjust_cn
 sub-nav-pos: 6

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust/Configuration.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust/Configuration.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: DynamicAdjust_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Configuration_cn
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: 动态更新配置
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust/Metrics.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust/Metrics.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: DynamicAdjust_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Metrics_cn
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: 动态调整Metrics
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust/Parallel.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/DynamicAdjust/Parallel.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: DynamicAdjust_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Parallel_cn
-#sub-nav-pos: 3
+# sub-nav-pos: 3
 sub-nav-title: 动态调整并发
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/PerformanceTuning.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/PerformanceTuning.md
@@ -2,7 +2,7 @@
 title:  "性能优化"
 layout: plain_cn
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: PerformanceTuning_cn
 sub-nav-pos: 10

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Plugins.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Plugins.md
@@ -2,7 +2,7 @@
 title:  "Plugins"
 layout: plain_cn
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Plugins_cn
 sub-nav-pos: 4

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Plugins/Flux.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Plugins/Flux.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: Plugins_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Flux_cn
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: Flux 插件
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Plugins/Hdfs.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Plugins/Hdfs.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: Plugins_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: HDFS_cn
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: HDFS 插件
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/SQL.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/SQL.md
@@ -2,7 +2,7 @@
 title:  "How to run SQL on jstorm"
 layout: plain_cn
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: SQL_cn
 sub-nav-pos: 7

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/SubmitTopology.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/SubmitTopology.md
@@ -2,7 +2,7 @@
 title:  "使用API提交Topology"
 layout: plain_cn
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: SubmitTopology_cn
 sub-nav-pos: 8

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Theory.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Theory.md
@@ -2,7 +2,7 @@
 title:  "Run mechanism & Theory"
 layout: plain_cn
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Theory_cn
 sub-nav-pos: 3

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Theory/Acker.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Theory/Acker.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: Theory_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Acker_cn
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: Acker 原理
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined.md
@@ -2,7 +2,7 @@
 title:  "User Defined Features"
 layout: plain_cn
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: UserDefined_cn
 sub-nav-pos: 5

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Alarm.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Alarm.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: UserDefined_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Alarm_cn
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: 自定义报错
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Log.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Log.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: UserDefined_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Log_cn
-#sub-nav-pos: 1
+# sub-nav-pos: 1
 sub-nav-title: 自定义日志
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Metrics.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Metrics.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: UserDefined_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Metrics_cn
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title:  自定义监控
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Scheduler.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/UserDefined/Scheduler.md
@@ -6,7 +6,7 @@ layout: plain_cn
 sub-nav-parent: UserDefined_cn
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Scheduler_cn
-#sub-nav-pos: 2
+# sub-nav-pos: 2
 sub-nav-title: 自定义调度
 ---
 

--- a/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Window.md
+++ b/docs/jstorm-doc/ProgrammingGuide_cn/AdvancedUsage/Window.md
@@ -2,7 +2,7 @@
 title:  "How to use Window Framework?"
 layout: plain_cn
 
-#sub-nav-parent: AdvancedUsage
+# sub-nav-parent: AdvancedUsage
 sub-nav-group: AdvancedUsage_cn
 sub-nav-id: Window_cn
 sub-nav-pos: 9

--- a/docs/jstorm-doc/QuickStart/BasicConception.md
+++ b/docs/jstorm-doc/QuickStart/BasicConception.md
@@ -9,8 +9,8 @@ top-nav-title: "Basic Conception"
 * This will be replaced by the TOC
 {:toc}
 
-#TO BE MODIFY
-#the architecture is quite different from the cn version
+# TO BE MODIFY
+# the architecture is quite different from the cn version
 
 ## Stream ##
 

--- a/docs/jstorm-doc/QuickStart/Compile.md
+++ b/docs/jstorm-doc/QuickStart/Compile.md
@@ -9,8 +9,8 @@ top-nav-title: Compile JStorm
 * This will be replaced by the TOC
 {:toc}
 
-#TO BE DONE 
-#need "PATCH TO THE COMMUNITY"
+# TO BE DONE 
+# need "PATCH TO THE COMMUNITY"
 
 
 

--- a/docs/jstorm-doc/backup/advance/perfomance_tuning.md
+++ b/docs/jstorm-doc/backup/advance/perfomance_tuning.md
@@ -37,20 +37,20 @@ When using fieldGrouping, please take care of hotpoint task which receive more d
 # Hotpoint worker
 For some heavy component, please make sure every worker's loader is almost equal, so the parallelism of the component had better be multiple of the worker number.
 
-#Hotpoint/Bad Supervisor
+# Hotpoint/Bad Supervisor
 Please pay attention to this problem When whole cluster's load is heavy. Here are several solution to resolve this problem:
 
 1. let the worker number is multiple of the supervisor number and reduce hotpoint  worker
 2. Do connection check after install one cluster, You can use the installation package's example to do this check.
 3. Check supervisor's page, check whether there are some workers whose one of CPU usage/"Batch Trans Time over network(ms)"/"Netty Client Batch Size" is pretty high
 
-#Hotpoint spout
+# Hotpoint spout
 Normally spout consumer Kafka/RockeMq/TimeTunel/Redis, the data source's partition number had better be the multiple of spout's number.
 
 # Worker number
 It had better run 2 ~ 8 tasks in one worker, the more data to be handled in one task, the smaller the number. Running multiple tasks in one worker will save much CPU, more data will be past in one process, no network cost, no serialize/deserialize operation. But the number bigger than 12 isn't be suggested, due to thread switch maybe cost much CPU.
 
-#Some JStorm setting for performance
+# Some JStorm setting for performance
 
 ```
 topology.max.spout.pending: null                 #this will effect spout emit tuple number in one time, the bigger it is, the more tuple it will emit, the easier occur failure

--- a/docs/jstorm-doc/backup/advance_cn/ack_cn.md
+++ b/docs/jstorm-doc/backup/advance_cn/ack_cn.md
@@ -41,7 +41,7 @@ ack机制即， spout发送的每一条消息，
 * 设置acker数等于0
 
 
-#Acker的原理：
+# Acker的原理：
 acker的原理如下图所示：
 
 ![acker]({{site.baseurl}}/img/advance_cn/ack/acker.jpg)

--- a/docs/jstorm-doc/backup/features/index.md
+++ b/docs/jstorm-doc/backup/features/index.md
@@ -2,4 +2,4 @@
 title: Features
 layout: plain
 ---
-#To be done.
+# To be done.

--- a/docs/jstorm-doc/backup/features_cn/index.md
+++ b/docs/jstorm-doc/backup/features_cn/index.md
@@ -2,4 +2,4 @@
 title: 特性
 layout: plain_cn
 ---
-#To be done.
+# To be done.

--- a/docs/jstorm-doc/backup/quickstart/web_ui.md
+++ b/docs/jstorm-doc/backup/quickstart/web_ui.md
@@ -12,12 +12,12 @@ User is able to manage multiple JStorm clusters using one single web UI after JS
 
 With the growing size of cluster and increasing number of clusters, especially small clusters, it is very difficult to launch a Web UI for each single cluster. Besides, normally launching a new Web UI for online applications requires examinations and approval in company, which will take a lot of time, so it's very necessary to manage multiple JStorm clusters using one single web UI.
 
-##Preparation
+## Preparation
 
 * A running web ui.  [How to Install Web UI]({{site.baseu}}/quickstart/install.html#install-jstorm-web-ui) 
 * The version of Web UI must align with the highest version of Jstorm cluster
 
-##Add a new cluster
+## Add a new cluster
 Edit ~/.jstorm/storm.yaml on the machine where Web UI running, here is the example:
 
 ```

--- a/docs/ui-rest-api.md
+++ b/docs/ui-rest-api.md
@@ -32,7 +32,7 @@ You can use a tool such as `curl` to talk to the REST API:
     # Note: We assume ui.port is configured to the default value of 8080.
     $ curl http://<ui-host>:8080/api/v2/cluster/configuration
 
-##Impersonating a user in secure environment
+## Impersonating a user in secure environment
 In a secure environment an authenticated user can impersonate another user. To impersonate a user the caller must pass
 `doAsUser` param or header with value set to the user that the request needs to be performed as. Please see SECURITY.MD
 to learn more about how to setup impersonation ACLs and authorization. The rest API uses the same configs and acls that

--- a/jstorm-utility/jstorm-flux/README.md
+++ b/jstorm-utility/jstorm-flux/README.md
@@ -315,7 +315,7 @@ components:
 
 ### 构造函数, 引用, 属性和方法 
 
-####构造函数
+#### 构造函数
 构造函数的形参可以通过`contructorArgs`来指定，`contructorArgs`是一个list，将会被传递到构造函数用来创建对象。比如下面的创建一个zkHosts
 对象：
 
@@ -327,7 +327,7 @@ components:
       - true
 ```
 
-####引用
+#### 引用
 每一个实例对象生成都必须指定一个唯一性ID，这样的话我们就可以在其他实例对象的创建或者调用过程中，利用该ID达到对其对应的实例引用。但是注意的是
 要在对象B中引用A对象的话，那么应该在定义创建B对象的配置文件中，用`ref` 来标识对象A所对应ID。
 下面的这个例子，就是一个实例对象率先被创建，其ID是`"stringScheme"` ，过后另外一个对象的构造函数要用到StringScheme作为形参，那么它就需要
@@ -345,7 +345,7 @@ components:
 ```
 **N.B.:** References can only be used after (below) the object they point to has been declared.
 
-####属性
+#### 属性
 除了调用构造函数来初始化对象的一些属性以外， Flux还支持用户可以通过配置文件来设置对象属性的值，前提是这些属性都有一个set方法，及该方法都是
 `public`：
 
@@ -377,7 +377,7 @@ look for a public instance variable with the name `forceFromStart` and attempt t
 References may also be used as property values.
 备注： 引用的方式也支持在yaml属性替换中使用
 
-####配置方法调用
+#### 配置方法调用
 在配置文件中配置对象的一些方法后，就自动会在实例化对象后，马上去调用这些方法。比如你不想通过构造函数的方式或者直接赋值的方式来设置某些属性的话，
 可以自定义一些方法来设置这些属性，这样做可以避免暴露一些属性的名称。
 

--- a/jstorm-utility/jstorm-flux/README_EN.md
+++ b/jstorm-utility/jstorm-flux/README_EN.md
@@ -355,7 +355,7 @@ components:
 
 ### Contructor Arguments, References, Properties and Configuration Methods
 
-####Constructor Arguments
+#### Constructor Arguments
 Arguments to a class constructor can be configured by adding a `contructorArgs` element to a components.
 `constructorArgs` is a list of objects that will be passed to the class' constructor. The following example creates an
 object by calling the constructor that takes a single string as an argument:
@@ -368,7 +368,7 @@ object by calling the constructor that takes a single string as an argument:
       - true
 ```
 
-####References
+#### References
 Each component instance is identified by a unique id that allows it to be used/reused by other components. To
 reference an existing component, you specify the id of the component with the `ref` tag.
 
@@ -387,7 +387,7 @@ components:
 ```
 **N.B.:** References can only be used after (below) the object they point to has been declared.
 
-####Properties
+#### Properties
 In addition to calling constructors with different arguments, Flux also allows you to configure components using
 JavaBean-like setter methods and fields declared as `public`:
 
@@ -416,7 +416,7 @@ look for a public instance variable with the name `forceFromStart` and attempt t
 
 References may also be used as property values.
 
-####Configuration Methods
+#### Configuration Methods
 Conceptually, configuration methods are similar to Properties and Constructor Args -- they allow you to invoke an
 arbitrary method on an object after it is constructed. Configuration methods are useful for working with classes that
 don't expose JavaBean methods or have constructors that can fully configure the object. Common examples include classes


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
