### PR TITLE
jstorm-core内冗余的实例化对象 (RedundantInstantiation) #489

### DIFF
--- a/jstorm-core/src/main/java/com/alibaba/jstorm/container/CgroupCenter.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/container/CgroupCenter.java
@@ -72,8 +72,7 @@ public class CgroupCenter implements CgroupOperation {
                 String name = strSplit[0];
                 String type = strSplit[3];
                 String dir = strSplit[1];
-                Hierarchy h = hierarchies.get(type);
-                h = new Hierarchy(name, CgroupUtils.analyse(type), dir);
+                Hierarchy h = new Hierarchy(name, CgroupUtils.analyse(type), dir);
                 hierarchies.put(type, h);
             }
             return new ArrayList<Hierarchy>(hierarchies.values());


### PR DESCRIPTION
我们的自动化缺陷检测工具扫描 jstorm-core的源代码，发现了一处潜在的 bug, 上述代码片段中，Hierarchy的对象h 被连续两次初始化，修改为：

`Hierarchy h = new Hierarchy(name, CgroupUtils.analyse(type), dir);`