### PR TITLE
fix jstorm-core 2.4.0 shaded gson package error

### DIFF
--- a/jstorm-core/pom.xml
+++ b/jstorm-core/pom.xml
@@ -103,8 +103,8 @@
                                     <shadedPattern>shade.storm.jline</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.google.code.gson</pattern>
-                                    <shadedPattern>shade.storm.com.google.code.gson</shadedPattern>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>shade.storm.com.google.gson</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.codahale.metrics</pattern>


### PR DESCRIPTION
relocate gson's relocation from com.google.code.gson  to com.google.gson