### PR TITLE
align guava version to 18.0

### DIFF
--- a/jstorm-utility/performance-test/pom.xml
+++ b/jstorm-utility/performance-test/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>16.0.1</version>
+            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
inconsistent version of guava found. Align versions to 18.0 to avoid inconsistent API behavior.