### PR TITLE
refactor: Use Java standard library instead of Guava

### DIFF
--- a/example/sequence-split-merge/src/main/java/com/alipay/dw/jstorm/example/newindow/FastWordCountTopNWindowTopology.java
+++ b/example/sequence-split-merge/src/main/java/com/alipay/dw/jstorm/example/newindow/FastWordCountTopNWindowTopology.java
@@ -34,7 +34,6 @@ import com.alibaba.jstorm.window.BaseWindowedBolt;
 import com.alibaba.jstorm.window.Time;
 import com.alibaba.jstorm.window.TimeWindow;
 import com.alibaba.starter.utils.JStormHelper;
-import com.google.common.collect.Lists;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -43,6 +42,8 @@ import java.util.Map;
 import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
 
 /**
  * WordCount but the spout does not stop, and the bolts are implemented in java.
@@ -203,7 +204,7 @@ public class FastWordCountTopNWindowTopology {
         public void purgeWindow(Object state, TimeWindow window) {
             LOG.info("purging window: {}", window);
             final HashMap<String, Integer> counts = (HashMap<String, Integer>) state;
-            List<String> keys = Lists.newArrayList(counts.keySet());
+            List<String> keys = new ArrayList<>(counts.keySet());
             Collections.sort(keys, new Comparator<String>() {
                 @Override
                 public int compare(String o1, String o2) {
@@ -211,7 +212,7 @@ public class FastWordCountTopNWindowTopology {
                 }
             });
 
-            List<Object> pairs = Lists.newArrayListWithCapacity(n);
+            List<Object> pairs = new ArrayList<>(n);
             for (int i = 0; i < n; i++) {
                 pairs.add(new Pair<>(keys.get(i), counts.get(keys.get(i))));
             }
@@ -264,7 +265,7 @@ public class FastWordCountTopNWindowTopology {
         @Override
         public void purgeWindow(Object state, TimeWindow window) {
             final HashMap<String, Integer> counts = (HashMap<String, Integer>) state;
-            List<String> keys = Lists.newArrayList(counts.keySet());
+            List<String> keys = new ArrayList<>(counts.keySet());
             Collections.sort(keys, new Comparator<String>() {
                 @Override
                 public int compare(String o1, String o2) {

--- a/example/sequence-split-merge/src/main/java/org/apache/storm/starter/tools/RankableObjectWithFields.java
+++ b/example/sequence-split-merge/src/main/java/org/apache/storm/starter/tools/RankableObjectWithFields.java
@@ -18,11 +18,11 @@
 package org.apache.storm.starter.tools;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import backtype.storm.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 /**
  * This class wraps an objects and its associated count, including any
@@ -67,7 +67,7 @@ public class RankableObjectWithFields implements Rankable, Serializable {
      * @return new instance based on the provided tuple
      */
     public static RankableObjectWithFields from(Tuple tuple) {
-        List<Object> otherFields = Lists.newArrayList(tuple.getValues());
+        List<Object> otherFields = new ArrayList<>(tuple.getValues());
         Object obj = otherFields.remove(0);
         Long count = (Long) otherFields.remove(0);
         return new RankableObjectWithFields(obj, count, otherFields.toArray());

--- a/example/sequence-split-merge/src/main/java/org/apache/storm/starter/tools/Rankings.java
+++ b/example/sequence-split-merge/src/main/java/org/apache/storm/starter/tools/Rankings.java
@@ -18,10 +18,11 @@
 package org.apache.storm.starter.tools;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class Rankings implements Serializable {
@@ -30,7 +31,7 @@ public class Rankings implements Serializable {
     private static final int  DEFAULT_COUNT    = 10;
     
     private final int            maxSize;
-    private final List<Rankable> rankedItems = Lists.newArrayList();
+    private final List<Rankable> rankedItems = new ArrayList<>();
     
     public Rankings() {
         this(DEFAULT_COUNT);
@@ -80,7 +81,7 @@ public class Rankings implements Serializable {
      * @return a somewhat defensive copy of ranked items
      */
     public List<Rankable> getRankings() {
-        List<Rankable> copy = Lists.newLinkedList();
+        List<Rankable> copy = new LinkedList<>();
         for (Rankable r : rankedItems) {
             copy.add(r.copy());
         }

--- a/jstorm-core/src/main/java/backtype/storm/command/blobstore.java
+++ b/jstorm-core/src/main/java/backtype/storm/command/blobstore.java
@@ -28,7 +28,6 @@ import com.alibaba.jstorm.cluster.Cluster;
 import com.alibaba.jstorm.cluster.StormClusterState;
 import com.alibaba.jstorm.cluster.StormConfig;
 import com.alibaba.jstorm.utils.PathUtils;
-import com.google.common.collect.Sets;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -65,7 +64,7 @@ public class blobstore {
         init();
         String stormRoot = StormConfig.masterStormdistRoot(conf);
         List<String> topologies = PathUtils.read_dir_contents(stormRoot);
-        Set<String> activeKeys = Sets.newHashSet(blobStore.listKeys());
+        Set<String> activeKeys = new HashSet<>(Arrays.asList(blobStore.listKeys()));
 
         for (String topologyId : topologies) {
             try {

--- a/jstorm-core/src/main/java/backtype/storm/command/gray_upgrade.java
+++ b/jstorm-core/src/main/java/backtype/storm/command/gray_upgrade.java
@@ -23,7 +23,6 @@ import backtype.storm.utils.CommandLineUtil;
 import backtype.storm.utils.NimbusClient;
 import backtype.storm.utils.Utils;
 import com.alibaba.jstorm.client.ConfigExtension;
-import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
 
 /**
  * gray upgrade a topology
@@ -128,7 +129,7 @@ public class gray_upgrade {
         if (commandLine.hasOption("w")) {
             String w = commandLine.getOptionValue("w");
             if (!StringUtils.isBlank(w)) {
-                workers = Lists.newArrayList();
+                workers = new ArrayList<>();
                 String[] parts = w.split(",");
                 for (String part : parts) {
                     if (part.split(":").length == 2) {

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/blobstore/BlobStoreUtils.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/blobstore/BlobStoreUtils.java
@@ -30,8 +30,6 @@ import com.alibaba.jstorm.daemon.nimbus.NimbusData;
 import com.alibaba.jstorm.metric.JStormMetrics;
 import com.alibaba.jstorm.utils.JStormServerUtils;
 import com.alibaba.jstorm.utils.JStormUtils;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.net.URL;
 import org.apache.commons.io.FileExistsException;
 import org.apache.commons.io.FileUtils;
@@ -341,7 +339,7 @@ public class BlobStoreUtils {
             CuratorFramework zkClient = null;
             try {
                 zkClient = BlobStoreUtils.createZKClient(conf);
-                nimbusInfos = Lists.newArrayList(BlobStoreUtils.getNimbodesWithLatestSequenceNumberOfBlob(zkClient, key));
+                nimbusInfos = new ArrayList<>(BlobStoreUtils.getNimbodesWithLatestSequenceNumberOfBlob(zkClient, key));
                 Collections.shuffle(nimbusInfos);
             } catch (Exception e) {
                 LOG.error("get available nimbus for blob key:{} error", e);
@@ -481,7 +479,7 @@ public class BlobStoreUtils {
                 return null;
             }
         };
-        return Sets.newHashSet(filterAndListKeys(iterator, keyFilter));
+        return new HashSet<>(Arrays.asList(filterAndListKeys(iterator, keyFilter)));
     }
 
     // remove blob information in zk for the blobkey

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/cache/rocksdb/RocksDbFactory.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/cache/rocksdb/RocksDbFactory.java
@@ -19,7 +19,6 @@ package com.alibaba.jstorm.cache.rocksdb;
 
 import backtype.storm.utils.Utils;
 import com.alibaba.jstorm.client.ConfigExtension;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
 import org.rocksdb.*;
@@ -104,7 +103,7 @@ public class RocksDbFactory {
     }
 
     private static List<Integer> getTtlValues(int ttlSec, List<ColumnFamilyDescriptor> descriptors) {
-        List<Integer> ttlValues = Lists.newArrayList();
+        List<Integer> ttlValues = new ArrayList<>();
         for (ColumnFamilyDescriptor descriptor : descriptors) {
             ttlValues.add(ttlSec);
         }
@@ -113,7 +112,7 @@ public class RocksDbFactory {
 
     private static List<ColumnFamilyDescriptor> getExistingColumnFamilyDesc(Map conf, String dbPath) throws IOException {
         try {
-            List<byte[]> families = Lists.newArrayList();
+            List<byte[]> families = new ArrayList<>();
             List<byte[]> existingFamilies = RocksDB.listColumnFamilies(getOptions(conf), dbPath);
             if (existingFamilies != null) {
                 families.addAll(existingFamilies);

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/callback/impl/RollbackTransitionCallback.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/callback/impl/RollbackTransitionCallback.java
@@ -27,10 +27,12 @@ import com.alibaba.jstorm.cluster.StormStatus;
 import com.alibaba.jstorm.daemon.nimbus.NimbusData;
 import com.alibaba.jstorm.daemon.nimbus.StatusType;
 import com.alibaba.jstorm.task.upgrade.GrayUpgradeConfig;
-import com.google.common.collect.Sets;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
 
 /**
  * @author wange
@@ -74,7 +76,7 @@ public class RollbackTransitionCallback extends BaseCallback {
                 upgradeConfig.setRollback(true);
                 stormClusterState.set_gray_upgrade_conf(topologyId, upgradeConfig);
 
-                Set<String> upgradedWorkers = Sets.newHashSet(stormClusterState.get_upgraded_workers(topologyId));
+                Set<String> upgradedWorkers = new HashSet<>(Arrays.asList(stormClusterState.get_upgraded_workers(topologyId)));
                 if (upgradedWorkers.size() > 0) {
                     LOG.info("Setting rollback workers:{}", upgradedWorkers);
                     for (String upgradedWorker : upgradedWorkers) {

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/cluster/StormZkClusterState.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/cluster/StormZkClusterState.java
@@ -32,7 +32,6 @@ import com.alibaba.jstorm.task.error.TaskError;
 import com.alibaba.jstorm.utils.JStormUtils;
 import com.alibaba.jstorm.utils.PathUtils;
 import com.alibaba.jstorm.utils.TimeUtils;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -844,7 +843,7 @@ public class StormZkClusterState implements StormClusterState {
     public List<String> get_upgrading_topologies() throws Exception {
         List<String> ret = cluster_state.get_children(Cluster.GRAY_UPGRADE_SUBTREE, false);
         if (ret == null) {
-            ret = Lists.newArrayList();
+            ret = new ArrayList<>();
         }
         return ret;
     }

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/common/metric/AsmMetric.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/common/metric/AsmMetric.java
@@ -47,7 +47,7 @@ public abstract class AsmMetric<T extends Metric> {
 
     protected static int minWindow = getMinWindow(windowSeconds);
     private static final int FLUSH_INTERVAL_BIAS = 5;
-    protected static final List<Integer> EMPTY_WIN = Lists.newArrayListWithCapacity(0);
+    protected static final List<Integer> EMPTY_WIN = new ArrayList<>(0);
 
     /**
      * sample rate for meter, histogram and timer, note that counter & gauge are not sampled.

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/config/YarnConfigBlacklist.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/config/YarnConfigBlacklist.java
@@ -28,10 +28,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
 
 /**
  * yarn config black list, note that ONLY plain K-V is supported, list/map values are not supported!!!
@@ -100,7 +101,7 @@ public class YarnConfigBlacklist implements Refreshable {
 
         StringBuilder sb = new StringBuilder(4096);
         Iterable<String> lines = splitLines(confData);
-        List<String> lineArray = Lists.newArrayList(lines);
+        List<String> lineArray = new ArrayList<>(lines);
         for (int i = 0; i < lineArray.size(); i++) {
             String trimmedLine = lineArray.get(i).trim();
             if (!trimmedLine.startsWith("#") && trimmedLine.contains(":")) {
@@ -138,7 +139,7 @@ public class YarnConfigBlacklist implements Refreshable {
 
         StringBuilder sb = new StringBuilder();
         Iterable<String> lines = splitLines(confData);
-        List<String> lineArray = Lists.newArrayList(lines);
+        List<String> lineArray = new ArrayList<>(lines);
         for (int i = 0; i < lineArray.size(); i++) {
             String trimmedLine = lineArray.get(i).trim();
             if (!trimmedLine.startsWith("#") && trimmedLine.contains(":")) {

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/nimbus/NimbusUtils.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/nimbus/NimbusUtils.java
@@ -52,14 +52,7 @@ import com.alibaba.jstorm.utils.TimeUtils;
 import com.google.common.collect.Sets;
 
 import java.security.InvalidParameterException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -314,11 +307,11 @@ public class NimbusUtils {
         BlobStore blobStore = data.getBlobStore();
 
         // we have only topology relative files , so we don't need filter
-        Set<String> code_ids = Sets.newHashSet(BlobStoreUtils.code_ids(blobStore.listKeys()));
+        Set<String> code_ids = new HashSet<>(Arrays.asList(BlobStoreUtils.code_ids(blobStore.listKeys())));
         // get topology in ZK /storms
-        Set<String> active_ids = Sets.newHashSet(data.getStormClusterState().active_storms());
+        Set<String> active_ids = new HashSet<>(Arrays.asList(data.getStormClusterState().active_storms()));
         //get topology in zk by blobs
-        Set<String> blobsIdsOnZk = Sets.newHashSet(data.getStormClusterState().blobstore(null));
+        Set<String> blobsIdsOnZk = new HashSet<>(Arrays.asList(data.getStormClusterState().blobstore(null)));
         Set<String> topologyIdsOnZkbyBlobs = BlobStoreUtils.code_ids(blobsIdsOnZk.iterator());
 
         Set<String> corrupt_ids = Sets.difference(active_ids, code_ids);

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/nimbus/ServiceHandler.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/nimbus/ServiceHandler.java
@@ -25,7 +25,6 @@ import com.alibaba.jstorm.task.upgrade.GrayUpgradeConfig;
 import com.alibaba.jstorm.utils.LoadConf;
 
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -35,11 +34,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
@@ -2011,7 +2006,7 @@ public class ServiceHandler implements Iface, Shutdownable, DaemonCommon {
             throw new NotAliveException(topologyName);
         }
 
-        Set<String> workerSet = (workers == null) ? Sets.<String>newHashSet() : Sets.<String>newHashSet(workers);
+        Set<String> workerSet = (workers == null) ? new HashSet<>() : new HashSet<>(workers);
         try {
             grayUpgrade(topologyId, null, null, Maps.newHashMap(), component, workerSet, workerNum);
         } catch (Exception ex) {
@@ -2079,8 +2074,8 @@ public class ServiceHandler implements Iface, Shutdownable, DaemonCommon {
         Assignment assignment = stormClusterState.assignment_info(topologyId, null);
         if (upgradeConfig != null) {
             LOG.info("Got existing gray upgrade config:{}", upgradeConfig);
-            Set<String> upgradingWorkers = Sets.newHashSet(stormClusterState.get_upgrading_workers(topologyId));
-            Set<String> upgradedWorkers = Sets.newHashSet(stormClusterState.get_upgraded_workers(topologyId));
+            Set<String> upgradingWorkers = new HashSet<>(Arrays.asList(stormClusterState.get_upgrading_workers(topologyId)));
+            Set<String> upgradedWorkers = new HashSet<>(Arrays.asList(stormClusterState.get_upgraded_workers(topologyId)));
             int upgradingWorkerNum = upgradingWorkers.size();
             int upgradedWorkerNum = upgradedWorkers.size();
             int totalWorkerNum = assignment.getWorkers().size() - 1;

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/nimbus/metric/refresh/RefreshEvent.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/nimbus/metric/refresh/RefreshEvent.java
@@ -21,11 +21,7 @@ import com.alibaba.jstorm.daemon.nimbus.metric.CheckMetricEvent;
 import com.alibaba.jstorm.utils.Pair;
 import com.alibaba.jstorm.utils.TimeUtils;
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,7 +43,6 @@ import com.alibaba.jstorm.metric.TimeTicker;
 import com.alibaba.jstorm.metric.TopologyMetricContext;
 import com.alibaba.jstorm.schedule.Assignment;
 import com.alibaba.jstorm.schedule.default_assign.ResourceWorkerSlot;
-import com.google.common.collect.Sets;
 
 /**
  * Sync meta <String, Long> from cache and remote
@@ -108,7 +103,7 @@ public class RefreshEvent extends MetricEvent {
                     //there's no need to consider sample rate when cluster metrics merge
                     conf.put(ConfigExtension.TOPOLOGY_METRIC_SAMPLE_RATE, 1.0);
                 }
-                Set<ResourceWorkerSlot> workerSlot = Sets.newHashSet(new ResourceWorkerSlot());
+                Set<ResourceWorkerSlot> workerSlot = new HashSet<>(Arrays.asList(new ResourceWorkerSlot()));
                 TopologyMetricContext metricContext = new TopologyMetricContext(topology, workerSlot, conf);
                 context.getTopologyMetricContexts().putIfAbsent(topology, metricContext);
                 syncMetaFromCache(topology, context.getTopologyMetricContexts().get(topology));

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/supervisor/ShutdownWork.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/supervisor/ShutdownWork.java
@@ -17,8 +17,8 @@
  */
 package com.alibaba.jstorm.daemon.supervisor;
 
-import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +77,7 @@ public class ShutdownWork extends RunnableCallback {
             try {
                 pids = getPid(conf, workerId);
             } catch (IOException e1) {
-                pids = Lists.newArrayList();
+                pids = new ArrayList<>();
                 LOG.error("Failed to get pid for " + workerId + " of " + topologyId);
             }
             workerId2Pids.put(workerId, pids);

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/supervisor/SyncSupervisorEvent.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/daemon/supervisor/SyncSupervisorEvent.java
@@ -33,7 +33,6 @@ import com.alibaba.jstorm.utils.JStormUtils;
 import com.alibaba.jstorm.utils.Pair;
 import com.alibaba.jstorm.utils.PathUtils;
 import com.alibaba.jstorm.utils.TimeUtils;
-import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -399,7 +398,7 @@ class SyncSupervisorEvent extends RunnableCallback {
         Map<String, Set<Pair<String, Integer>>> ret = new HashMap<>();
 
         try {
-            Set<String> upgradingTopologies = Sets.newHashSet(stormClusterState.get_upgrading_topologies());
+            Set<String> upgradingTopologies = new HashSet<>(Arrays.asList(stormClusterState.get_upgrading_topologies()));
             for (String topologyId : upgradingTopologies) {
                 List<String> upgradingWorkers = stormClusterState.get_upgrading_workers(topologyId);
                 for (String worker : upgradingWorkers) {

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/metric/DefaultMetricQueryClient.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/metric/DefaultMetricQueryClient.java
@@ -20,8 +20,8 @@ package com.alibaba.jstorm.metric;
 import com.alibaba.jstorm.common.metric.MetricMeta;
 import com.alibaba.jstorm.common.metric.TaskTrack;
 import com.alibaba.jstorm.common.metric.TopologyHistory;
-import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -48,32 +48,32 @@ public class DefaultMetricQueryClient implements MetricQueryClient {
 
     @Override
     public List<MetricMeta> getMetricMeta(String clusterName, String topologyId, MetaType type, MetaFilter filter, Object arg) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<MetricMeta> getMetricMeta(String clusterName, String topologyId, MetaType type) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<MetricMeta> getWorkerMeta(String clusterName, String topologyId) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<MetricMeta> getNettyMeta(String clusterName, String topologyId) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<MetricMeta> getTaskMeta(String clusterName, String topologyId, int taskId) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<MetricMeta> getComponentMeta(String clusterName, String topologyId, String componentId) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
@@ -88,27 +88,27 @@ public class DefaultMetricQueryClient implements MetricQueryClient {
 
     @Override
     public List<Object> getMetricData(String metricId, MetricType metricType, int win, long start, long end) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<Object> getMetricData(String metricId, MetricType metricType, int win, long start, long end, int size) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<TaskTrack> getTaskTrack(String clusterName, String topologyId) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<TaskTrack> getTaskTrack(String clusterName, String topologyId, int taskId) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override
     public List<TopologyHistory> getTopologyHistory(String clusterName, String topologyName, int size) {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     @Override

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/metric/JStormMetricCache.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/metric/JStormMetricCache.java
@@ -27,7 +27,6 @@ import com.alibaba.jstorm.client.ConfigExtension;
 import com.alibaba.jstorm.cluster.StormClusterState;
 import com.alibaba.jstorm.cluster.StormConfig;
 import com.alibaba.jstorm.utils.OSInfo;
-import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -250,7 +249,7 @@ public class JStormMetricCache {
                 retMap.put((Long) objects[0], (MetricInfo) objects[1]);
             }
         }
-        List<MetricInfo> ret = Lists.newArrayList(retMap.values());
+        List<MetricInfo> ret = new ArrayList<>(retMap.values());
         int cnt = 0;
         for (MetricInfo metricInfo : ret) {
             cnt += metricInfo.get_metrics_size();

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/metric/JStormMetrics.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/metric/JStormMetrics.java
@@ -24,8 +24,6 @@ import com.alibaba.jstorm.common.metric.*;
 import com.alibaba.jstorm.common.metric.snapshot.AsmSnapshot;
 import com.alibaba.jstorm.utils.NetWorkUtils;
 import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +48,7 @@ public class JStormMetrics implements Serializable {
             NIMBUS_METRIC_KEY, CLUSTER_METRIC_KEY, SUPERVISOR_METRIC_KEY
     };
 
-    public static final Set<String> SYS_TOPOLOGY_SET = Sets.newHashSet(SYS_TOPOLOGIES);
+    public static final Set<String> SYS_TOPOLOGY_SET = new HashSet<>(Arrays.asList(SYS_TOPOLOGIES));
 
     public static final String DEFAULT_GROUP = "sys";
     public static final String NETTY_GROUP = "netty";
@@ -188,11 +186,11 @@ public class JStormMetrics implements Serializable {
         } else if (metaType == MetaType.WORKER) {
             return search(workerMetrics, metricName, metricType);
         }
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     private static List<AsmMetric> search(AsmMetricRegistry registry, String metricName, MetricType metricType) {
-        List<AsmMetric> ret = Lists.newArrayList();
+        List<AsmMetric> ret = new ArrayList<>();
 
         Map<String, ?> metricMap;
         if (metricType == MetricType.COUNTER) {
@@ -402,7 +400,7 @@ public class JStormMetrics implements Serializable {
         long start = System.currentTimeMillis();
         MetricInfo metricInfo = MetricUtils.mkMetricInfo();
 
-        List<Map.Entry<String, AsmMetric>> entries = Lists.newLinkedList();
+        List<Map.Entry<String, AsmMetric>> entries = new LinkedList<>();
         if (enableStreamMetrics) {
             entries.addAll(streamMetrics.metrics.entrySet());
         }
@@ -530,7 +528,7 @@ public class JStormMetrics implements Serializable {
             Set<AsmMetric> assocMetrics = metric.getAssocMetrics();
             MetricType metricType = MetricUtils.metricType(metric.getMetricName());
 
-            List<AsmMetric> asmMetricList = Lists.newLinkedList(assocMetrics);
+            List<AsmMetric> asmMetricList = new LinkedList<>(assocMetrics);
             asmMetricList.add(metric);
 
             // snapshot of the root metric: stream/task

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/schedule/FollowerRunnable.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/schedule/FollowerRunnable.java
@@ -134,8 +134,8 @@ public class FollowerRunnable implements Runnable {
     private void setupBlobstore() throws Exception {
         BlobStore blobStore = data.getBlobStore();
         StormClusterState clusterState = data.getStormClusterState();
-        Set<String> localSetOfKeys = Sets.newHashSet(blobStore.listKeys());
-        Set<String> allKeys = Sets.newHashSet(clusterState.active_keys());
+        Set<String> localSetOfKeys = new HashSet<>(Arrays.asList(blobStore.listKeys()));
+        Set<String> allKeys = new HashSet<>(Arrays.asList(clusterState.active_keys()));
         Set<String> localAvailableActiveKeys = Sets.intersection(localSetOfKeys, allKeys);
         // keys on local but not on zk, we will delete it
         Set<String> keysToDelete = Sets.difference(localSetOfKeys, allKeys);
@@ -221,8 +221,8 @@ public class FollowerRunnable implements Runnable {
             try {
                 BlobStore blobStore = data.getBlobStore();
                 StormClusterState clusterState = data.getStormClusterState();
-                Set<String> localKeys = Sets.newHashSet(blobStore.listKeys());
-                Set<String> zkKeys = Sets.newHashSet(clusterState.blobstore(blobSyncCallback));
+                Set<String> localKeys = new HashSet<>(Arrays.asList(blobStore.listKeys()));
+                Set<String> zkKeys = new HashSet<>(Arrays.asList(clusterState.blobstore(blobSyncCallback)));
                 BlobSynchronizer blobSynchronizer = new BlobSynchronizer(blobStore, data.getConf());
                 blobSynchronizer.setNimbusInfo(data.getNimbusHostPortInfo());
                 blobSynchronizer.setBlobStoreKeySet(localKeys);
@@ -305,8 +305,8 @@ public class FollowerRunnable implements Runnable {
         // but if we use local blobstore, we should count topologies files
         int diffCount = 0;
         if (data.getBlobStore() instanceof LocalFsBlobStore) {
-            Set<String> keysOnZk = Sets.newHashSet(zkClusterState.active_keys());
-            Set<String> keysOnLocal = Sets.newHashSet(data.getBlobStore().listKeys());
+            Set<String> keysOnZk = new HashSet<>(Arrays.asList(zkClusterState.active_keys()));
+            Set<String> keysOnLocal = new HashSet<>(Arrays.asList(data.getBlobStore().listKeys()));
             // we count number of keys which is on zk but not on local
             diffCount = Sets.difference(keysOnZk, keysOnLocal).size();
         }

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/task/master/GrayUpgradeHandler.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/task/master/GrayUpgradeHandler.java
@@ -23,7 +23,6 @@ import com.alibaba.jstorm.cluster.StormStatus;
 import com.alibaba.jstorm.daemon.nimbus.StatusType;
 import com.alibaba.jstorm.schedule.default_assign.ResourceWorkerSlot;
 import com.alibaba.jstorm.task.upgrade.GrayUpgradeConfig;
-import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,6 +32,8 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
 
 /**
  * @author wange
@@ -62,7 +63,7 @@ public class GrayUpgradeHandler implements TMHandler, Runnable {
         for (ResourceWorkerSlot workerSlot : tmContext.getWorkerSet().get()) {
             Set<Integer> tasks = workerSlot.getTasks();
             String hostPort = workerSlot.getHostPort();
-            hostPortToTasks.put(hostPort, Sets.newHashSet(tasks));
+            hostPortToTasks.put(hostPort, new HashSet<>(tasks));
 
             for (Integer task : tasks) {
                 this.taskToHostPort.put(task, hostPort);
@@ -115,7 +116,7 @@ public class GrayUpgradeHandler implements TMHandler, Runnable {
             }
 
             // notify current upgrading workers to upgrade (again)
-            Set<String> upgradingWorkers = Sets.newHashSet(stormClusterState.get_upgrading_workers(topologyId));
+            Set<String> upgradingWorkers = new HashSet<>(Arrays.asList(stormClusterState.get_upgrading_workers(topologyId)));
             if (upgradingWorkers.size() > 0) {
                 LOG.info("Following workers are under upgrade:{}", upgradingWorkers);
                 for (String worker : upgradingWorkers) {
@@ -124,7 +125,7 @@ public class GrayUpgradeHandler implements TMHandler, Runnable {
                 return;
             }
 
-            Set<String> upgradedWorkers = Sets.newHashSet(stormClusterState.get_upgraded_workers(topologyId));
+            Set<String> upgradedWorkers = new HashSet<>(Arrays.asList(stormClusterState.get_upgraded_workers(topologyId)));
             if (grayUpgradeConf.isRollback()) {
                 LOG.info("Rollback has completed, removing upgrade info in zk and updating storm status...");
                 // there's no way back after a rollback

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/transactional/bolt/KvStatefulBoltExecutor.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/transactional/bolt/KvStatefulBoltExecutor.java
@@ -24,7 +24,8 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+
 import com.google.common.collect.Maps;
 
 import backtype.storm.generated.GlobalStreamId;
@@ -81,7 +82,7 @@ public abstract class KvStatefulBoltExecutor<K, V> extends KvTransactionStateOpe
         if (fields.size() == 1) {
             key = input.getValueByField(fields.get(0));
         } else {
-            List<Object> fieldedValuesTobeHash = Lists.newArrayList();
+            List<Object> fieldedValuesTobeHash = new ArrayList<>();
             for (String field : fields) {
                 fieldedValuesTobeHash.add(input.getValueByField(field));
             }

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/window/SlidingCountWindows.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/window/SlidingCountWindows.java
@@ -20,7 +20,8 @@ package com.alibaba.jstorm.window;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.tuple.TupleImpl;
-import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -49,7 +50,7 @@ public class SlidingCountWindows<T> extends WindowAssigner<T> {
             start = 0;
         }
 
-        List<TimeWindow> windows = Lists.newArrayList();
+        List<TimeWindow> windows = new ArrayList<>();
         for (long nextStart = start; offset >= nextStart; nextStart += slide) {
             if (offset < nextStart + size) {
                 windows.add(new TimeWindow(nextStart, nextStart + size));

--- a/jstorm-core/src/main/java/com/alibaba/jstorm/window/WindowedBoltExecutor.java
+++ b/jstorm-core/src/main/java/com/alibaba/jstorm/window/WindowedBoltExecutor.java
@@ -31,13 +31,7 @@ import com.alibaba.jstorm.metric.MetricClient;
 import com.alibaba.jstorm.transactional.state.ITransactionStateOperator;
 import com.alibaba.jstorm.utils.JStormUtils;
 import com.alibaba.jstorm.utils.TimeUtils;
-import com.google.common.collect.Sets;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
@@ -316,7 +310,7 @@ public class WindowedBoltExecutor implements IRichBolt, Triggerable {
         if (WindowAssigner.isSessionTime(windowAssigner)) {
             // session windows don't slide
             TimeWindow sessionWindow = windows.iterator().next();
-            Set<TimeWindow> oldWindows = Sets.newHashSet(windowToTriggers.keySet());
+            Set<TimeWindow> oldWindows = new HashSet<>(Arrays.asList(windowToTriggers.keySet()));
             for (TimeWindow oldWindow : oldWindows) {
                 if (!oldWindow.equals(sessionWindow)) {
                     TimeWindow mergedWindow = mergeSessionWindows(oldWindow, sessionWindow);

--- a/jstorm-utility/jstorm-elasticsearch/src/main/java/com/alibaba/jstorm/elasticsearch/common/EsConfig.java
+++ b/jstorm-utility/jstorm-elasticsearch/src/main/java/com/alibaba/jstorm/elasticsearch/common/EsConfig.java
@@ -20,17 +20,13 @@ package com.alibaba.jstorm.elasticsearch.common;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 public class EsConfig implements Serializable {
   
@@ -69,7 +65,7 @@ public class EsConfig implements Serializable {
   }
 
   List<TransportAddress> getTransportAddresses() throws UnknownHostException {
-    List<TransportAddress> transportAddresses = Lists.newArrayList();
+    List<TransportAddress> transportAddresses = new ArrayList<>();
     for (String node : nodes) {
       String[] hostAndPort = node.split(DELIMITER);
       Preconditions.checkArgument(hostAndPort.length == 2,


### PR DESCRIPTION
Replacing uses of Guava with Java standard library so that we may be able to remove Guava at some point.

Co-authored-by: Moderne <team@moderne.io>