### PR TITLE
fix(sec): upgrade commons-collections:commons-collections to 3.2.2

### DIFF
--- a/example/sequence-split-merge/pom.xml
+++ b/example/sequence-split-merge/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/jstorm-utility/performance-test/pom.xml
+++ b/jstorm-utility/performance-test/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-collections:commons-collections 3.2.1
- [MPS-2022-12767](https://www.oscs1024.com/hd/MPS-2022-12767)


### What did I do？
Upgrade commons-collections:commons-collections from 3.2.1 to 3.2.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS